### PR TITLE
Fix stylelint rules for BEM naming convention

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,5 +2,8 @@
   "extends": [
     "stylelint-config-standard-scss",
     "stylelint-config-prettier-scss"
-  ]
+  ],
+  "rules": {
+    "selector-class-pattern": "^[a-z][a-zA-Z0-9_-]+$"
+  }
 }


### PR DESCRIPTION
Fix stylelint rules for BEM naming convention