### PR TITLE
ajusta el componente de beneficios

### DIFF
--- a/src/scss/components/beneficios.scss
+++ b/src/scss/components/beneficios.scss
@@ -1,9 +1,12 @@
-.experience-container {
+.experience {
   @include container-desktop;
+}
 
+.experience-container {
   margin: 40px 16px;
   display: flex;
   flex-flow: column-reverse;
+  align-items: flex-start;
 
   @include breakpoint('lg') {
     flex-flow: wrap;
@@ -11,12 +14,15 @@
 
   &__imagen {
     width: 100%;
-    text-align: right;
+    text-align: center;
     padding: 0 20px;
 
     img {
       margin-top: 24px;
+      max-width: 400px;
+      height: auto;
     }
+
     @include breakpoint('lg') {
       width: 40%;
     }

--- a/src/scss/components/beneficios.scss
+++ b/src/scss/components/beneficios.scss
@@ -1,81 +1,79 @@
-#experience {
-  margin: 80px 0;
+.experience-container {
+  @include container-desktop;
 
-  .experience-container {
-    width: 90%;
-    max-width: 1200px;
-    margin: auto;
-    display: flex;
-    flex-flow: column-reverse;
-    @include breakpoint('md') {
-      flex-flow: wrap;
+  margin: 40px 16px;
+  display: flex;
+  flex-flow: column-reverse;
+
+  @include breakpoint('lg') {
+    flex-flow: wrap;
+  }
+
+  &__imagen {
+    width: 100%;
+    text-align: right;
+    padding: 0 20px;
+
+    img {
+      margin-top: 24px;
+    }
+    @include breakpoint('lg') {
+      width: 40%;
     }
   }
-}
 
-.experience-container__imagen {
-  width: 100%;
-  text-align: right;
-  padding: 0 20px;
+  &__text {
+    font-size: 16px;
+    width: 100%;
 
-  img {
-    margin-top: 5%;
-  }
-  @include breakpoint('md') {
-    width: 40%;
-  }
-}
-
-.experience-container__text {
-  font-size: 16px;
-  width: 100%;
-
-  h4 {
-    font-family: var(--font-playfair-display);
-    font-size: 32px;
-    font-weight: 500;
-    line-height: 48px;
-    letter-spacing: 0;
-    text-align: left;
-    color: #212966;
-  }
-
-  @include breakpoint('md') {
-    width: 60%;
-    font-size: 32px;
-    padding: 20px 15px;
-  }
-}
-
-.text__proceeds {
-  background: #e6f2ff;
-  box-sizing: border-box;
-  border-radius: 10px;
-  color: #21295c;
-
-  .text__module {
-    background: #e6f2ff;
-    box-sizing: border-box;
-    border-radius: 10px;
-    color: #21295c;
-    padding: 12px 24px;
-    margin: 27px 0;
-
-    h5 {
-      font-size: 16px;
-      line-height: 24%;
+    @include breakpoint('lg') {
+      width: 60%;
+      padding: 20px 15px;
     }
 
-    p {
-      font-size: 16px;
-      line-height: 150%;
+    h4 {
+      font-family: var(--font-playfair-display);
+      font-size: 20px;
+      line-height: 30px;
+      font-weight: 500;
+      letter-spacing: 0;
+      text-align: left;
+      color: var(--space-blue);
+
+      @include breakpoint('lg') {
+        font-size: 32px;
+        line-height: 48px;
+      }
     }
   }
-}
 
-.experience-container__purchase {
-  background: #ffb5a7;
-  border-radius: 24px;
-  font-size: 16px;
-  padding: 8px 24px;
+  & .text__proceeds {
+    .text__module {
+      background: var(--alice-blue);
+      box-sizing: border-box;
+      border-radius: 10px;
+      color: var(--space-blue);
+      padding: 12px 24px;
+      margin: 27px 0;
+
+      h5 {
+        font-size: 16px;
+        line-height: 24px;
+        font-weight: 600;
+      }
+
+      p {
+        font-size: 16px;
+        line-height: 24px;
+        font-weight: 400;
+      }
+    }
+  }
+
+  & .experience-container__purchase {
+    background: var(--melon);
+    border-radius: 24px;
+    font-size: 16px;
+    padding: 8px 24px;
+  }
 }

--- a/templates/beneficios.hbs
+++ b/templates/beneficios.hbs
@@ -1,4 +1,4 @@
-<section id="experience">
+<section class="experience">
   <div class="experience-container">
     <div class="experience-container__imagen">
 	<img src='{{assetSrc imagen}}' alt='{{assetTitle imagen}}'>


### PR DESCRIPTION
Ajusta el componente de beneficios.
Para seguir el standar de BEM al construir los estilos.
Para usar las constantes de los colores.

DESKTOP
<img width="1320" alt="Screenshot 2022-11-06 at 3 20 54 PM" src="https://user-images.githubusercontent.com/4704524/200193148-3c812b24-c4a4-4028-9a32-f251fc4c5f47.png">
MOBILE
<img width="1322" alt="Screenshot 2022-11-06 at 3 21 11 PM" src="https://user-images.githubusercontent.com/4704524/200193164-25e4956f-3f56-431e-a90f-6bc27a15a36d.png">

CÓMO PROBAR

* Cambiarse a la rama `componente/beneficios-ajustes`
* Correr el comando `npm run dev`
* Ir a localhost:8080
