### PR TITLE
agrega container para desktop a componentes existentes

### DIFF
--- a/src/scss/components/footer.scss
+++ b/src/scss/components/footer.scss
@@ -1,4 +1,6 @@
 .footer {
+  @include container-desktop;
+
   background-color: var(--space-blue);
   color: var(--white);
   padding: 56px 16px;

--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -1,6 +1,8 @@
 .header {
+  @include container-desktop;
+
   display: flex;
-  margin: 2.1rem 1.6rem 0;
+  margin: 2.1rem auto 0;
   padding-bottom: 1.7rem;
   justify-content: space-between;
   align-items: center;
@@ -83,7 +85,7 @@
 
 @include breakpoint('lg') {
   .header {
-    margin: 1.6rem 6rem 0;
+    margin: 1.6rem auto 0;
     padding-bottom: 2.4rem;
     position: relative;
     justify-content: center;


### PR DESCRIPTION
Agrega el mixin de container desktop a los componentes ya desarrollados.
Con este cambio se habilita un tamaño de pantalla máximo para los contenedores.
FOOTER
<img width="1481" alt="Screenshot 2022-11-08 at 7 29 07 AM" src="https://user-images.githubusercontent.com/4704524/200563857-11d9398c-250a-44ea-8ec7-69a300d8e577.png">
HEADER
<img width="1478" alt="Screenshot 2022-11-08 at 7 29 28 AM" src="https://user-images.githubusercontent.com/4704524/200563920-4719c14f-34ad-4649-bee1-4105eb8d5a9c.png">

