### PR TITLE
agrega los estilos para el componente de servicios

### DIFF
--- a/src/scss/components/servicios.scss
+++ b/src/scss/components/servicios.scss
@@ -27,6 +27,7 @@
     @include breakpoint(lg) {
       display: flex;
       flex-direction: row;
+      justify-content: center;
     }
   }
 
@@ -35,6 +36,7 @@
     margin: 0 24px 24px;
     align-items: center;
     box-sizing: border-box;
+    max-width: 30%;
 
     & figure {
       width: 100%;

--- a/src/scss/components/servicios.scss
+++ b/src/scss/components/servicios.scss
@@ -1,0 +1,83 @@
+.servicios {
+  position: relative;
+  padding: 40px 0 48px;
+  background-color: var(--baby-blue);
+  display: flex;
+  flex-direction: column;
+  @include container-desktop;
+
+  &--titulo {
+    color: var(--space-blue);
+    text-align: center;
+  }
+
+  &--descripcion {
+    color: var(--space-blue);
+    text-align: center;
+    border-top: solid 1px var(--pale-purple);
+    border-bottom: solid 1px var(--pale-purple);
+    width: calc(100% - 2rem);
+    box-sizing: border-box;
+    display: block;
+    margin: 0 1rem 40px;
+    padding: 1rem;
+  }
+
+  &--tarjetas {
+    @include breakpoint(lg) {
+      display: flex;
+      flex-direction: row;
+    }
+  }
+
+  &--tarjeta {
+    width: calc(100% - 48px);
+    margin: 0 24px 24px;
+    align-items: center;
+    box-sizing: border-box;
+
+    & figure {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+
+      & img {
+        width: 100%;
+        height: auto;
+        display: block;
+      }
+
+      & figcaption {
+        text-align: center;
+        font-family: var(--font-playfair-display);
+        font-size: 2.2rem;
+        font-weight: 500;
+        line-height: 3.4rem;
+        color: var(--space-blue);
+        margin: 24px 0;
+
+        @include breakpoint(lg) {
+          font-size: 3.2rem;
+          line-height: 4.8rem;
+        }
+      }
+
+      & a {
+        text-align: center;
+        line-height: 24px;
+        background: var(--melon);
+        border-radius: 24px;
+        font-size: 16px;
+        padding: 8px 24px;
+        width: fit-content;
+        margin: 0 auto;
+        color: var(--space-blue);
+
+        &:visited {
+          color: var(--purple);
+        }
+      }
+    }
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -19,3 +19,4 @@
 @import './components/specialkit';
 @import './components/galeriaProducto';
 @import './components/producto';
+@import './components/servicios';

--- a/templates/servicios.hbs
+++ b/templates/servicios.hbs
@@ -1,7 +1,9 @@
-<section>
-	<h2>{{titulo}}</h2>
-	<p>{{descripcion}}</p>
-	{{#each card}}
-		<div>{{{module this}}}</div>
-	{{/each}}
+<section class="servicios">
+	<h2 class="servicios--titulo heading-2">{{titulo}}</h2>
+	<p class="servicios--descripcion body">{{descripcion}}</p>
+	<div class="servicios--tarjetas">
+		{{#each card}}
+			<div class="servicios--tarjeta">{{{module this}}}</div>
+		{{/each}}
+	</div>
 </section>


### PR DESCRIPTION
Agrega los estilos para el componente de servicios

INSTRUCCIONES PARA PROBAR

- Clonar la rama `feature/componente-servicios`
- Correr el comando `npm run dev`
- Usar las herramientas de desarrollador para visualizar la página en mobile o desktop (ej: 600px y 1441px)
- navegar a localhost:8080/index.html

MOBILE
<img width="1322" alt="Screenshot 2022-11-14 at 12 03 13 PM" src="https://user-images.githubusercontent.com/4704524/201721304-f797dd8d-9f23-4fcc-ac24-4e74032bbf3a.png">
DESKTOP
<img width="1323" alt="Screenshot 2022-11-14 at 12 03 55 PM" src="https://user-images.githubusercontent.com/4704524/201721452-04180de4-1218-4178-b6e7-14e0b68697bb.png">
