### PR TITLE
Ajusta los espacios a los lados del header para que se vea como en lo…

### DIFF
--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -1,14 +1,20 @@
 .header {
   @include container-desktop;
 
-  display: flex;
-  margin: 2.1rem auto 0;
-  padding-left: 2rem;
-  padding-right: 2rem;
-  padding-bottom: 1.7rem;
-  justify-content: space-between;
-  align-items: center;
-  border-bottom: 1px solid var(--pale-pink);
+  margin: 0 auto;
+
+  &__container {
+    display: flex;
+    flex-direction: row;
+    margin: 2.1rem 1.6rem 0;
+
+    // padding-left: 2rem;
+    // padding-right: 2rem;
+    padding-bottom: 1.7rem;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--pale-pink);
+  }
 
   &__logo {
     width: 12rem;
@@ -87,10 +93,14 @@
 
 @include breakpoint('lg') {
   .header {
-    margin: 1.6rem auto 0;
-    padding-bottom: 2.4rem;
-    position: relative;
-    justify-content: center;
+    padding: 0 6rem;
+
+    &__container {
+      margin: 2.3rem auto 0;
+      padding-bottom: 2.4rem;
+      position: relative;
+      justify-content: center;
+    }
 
     .burger-menu {
       display: none;

--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -7,9 +7,6 @@
     display: flex;
     flex-direction: row;
     margin: 2.1rem 1.6rem 0;
-
-    // padding-left: 2rem;
-    // padding-right: 2rem;
     padding-bottom: 1.7rem;
     justify-content: space-between;
     align-items: center;

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -1,34 +1,36 @@
 <header class="header">
-	<a href={{enlaceHome}} class="header-enlacehome">
-		<img src='{{assetSrc logo}}' alt='{{assetTitle logo}}' class="header__logo" />
-	</a>
-	<div class="burger-menu" id="burger-menu">
-		<svg width="18" height="12" viewBox="0 0 18 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<path fill-rule="evenodd" clip-rule="evenodd"
-				d="M0 11C0 11.5523 0.447715 12 1 12H17C17.5523 12 18 11.5523 18 11C18 10.4477 17.5523 10 17 10H1C0.447716 10 0 10.4477 0 11ZM0 6C0 6.55228 0.447715 7 1 7H17C17.5523 7 18 6.55228 18 6C18 5.44772 17.5523 5 17 5H1C0.447716 5 0 5.44772 0 6ZM1 0C0.447716 0 0 0.447715 0 1C0 1.55228 0.447715 2 1 2H17C17.5523 2 18 1.55228 18 1C18 0.447715 17.5523 0 17 0H1Z"
-				fill="#212966" />
-		</svg>
-	</div>
-	<div class="menu" id="menu">
-		<ul class="header__enlaces">
-			{{#each enlacesHeader}}
-			<li>{{{module this}}}</li>
-			{{/each}}
-		</ul>
-	</div>
-	<div class="menu-mobile" id="menu-mobile">
-		<div class="close-button" id="close-button">
-			<svg width="18" height="18" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<path
-					d="M0.457528 13.657L6.11438 8.00011L0.457528 2.34325L2.34315 0.457635L8 6.11449L13.6569 0.457635L15.5425 2.34325L9.88562 8.00011L15.5425 13.657L13.6569 15.5426L8 9.88572L2.34315 15.5426L0.457528 13.657Z"
-					fill="#212966" />
-			</svg>
-		</div>
-		<ul class="header__enlaces menu-mobile__enlaces">
-			{{#each enlacesHeader}}
-			<li>{{{module this}}}</li>
-			<span class="divider"></span>
-			{{/each}}
-		</ul>
-	</div>
+  <div class="header__container">
+    <a href={{enlaceHome}} class="header-enlacehome">
+      <img src='{{assetSrc logo}}' alt='{{assetTitle logo}}' class="header__logo" />
+    </a>
+    <div class="burger-menu" id="burger-menu">
+      <svg width="18" height="12" viewBox="0 0 18 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+          d="M0 11C0 11.5523 0.447715 12 1 12H17C17.5523 12 18 11.5523 18 11C18 10.4477 17.5523 10 17 10H1C0.447716 10 0 10.4477 0 11ZM0 6C0 6.55228 0.447715 7 1 7H17C17.5523 7 18 6.55228 18 6C18 5.44772 17.5523 5 17 5H1C0.447716 5 0 5.44772 0 6ZM1 0C0.447716 0 0 0.447715 0 1C0 1.55228 0.447715 2 1 2H17C17.5523 2 18 1.55228 18 1C18 0.447715 17.5523 0 17 0H1Z"
+          fill="#212966" />
+      </svg>
+    </div>
+    <div class="menu" id="menu">
+      <ul class="header__enlaces">
+        {{#each enlacesHeader}}
+        <li>{{{module this}}}</li>
+        {{/each}}
+      </ul>
+    </div>
+  </div>
+  <div class="menu-mobile" id="menu-mobile">
+    <div class="close-button" id="close-button">
+      <svg width="18" height="18" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path
+          d="M0.457528 13.657L6.11438 8.00011L0.457528 2.34325L2.34315 0.457635L8 6.11449L13.6569 0.457635L15.5425 2.34325L9.88562 8.00011L15.5425 13.657L13.6569 15.5426L8 9.88572L2.34315 15.5426L0.457528 13.657Z"
+          fill="#212966" />
+      </svg>
+    </div>
+    <ul class="header__enlaces menu-mobile__enlaces">
+      {{#each enlacesHeader}}
+      <li>{{{module this}}}</li>
+      <span class="divider"></span>
+      {{/each}}
+    </ul>
+  </div>
 </header>


### PR DESCRIPTION
Ajusta los espacios a los lados del header para que se vea como en los diseños en Figma

**Pasos para probar**

1. Clonar la rama header-bug-fix
2. Correr el comando npm run dev
3. Ir a la página http://localhost:8080/blog.html
4. Usar las herramientas de desarrollador para ver los viewports mobile y desktop

**Mobile**
<img width="426" alt="Mobile" src="https://user-images.githubusercontent.com/28935600/207224896-73881ddf-201d-4a18-89f7-bf4c506a3da2.png">

**Desktop**
<img width="1789" alt="Desktop" src="https://user-images.githubusercontent.com/28935600/207224934-3854ef37-3b3e-4da3-a4f8-3212a16c70db.png">

