### PR TITLE
Agrega el componente separador con estilos y ajusta un espacio de már…

### DIFF
--- a/src/scss/components/entradaBlog.scss
+++ b/src/scss/components/entradaBlog.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin: 3.6rem 1.6rem;
+  margin: 3.2rem 1.6rem;
 
   &__texto {
     height: fit-content;
@@ -74,6 +74,7 @@
     align-items: flex-start;
     gap: 8rem;
     border-bottom: 0.1rem solid var(--pale-purple);
+    margin: 4rem auto;
 
     &__texto {
       max-width: 100%;

--- a/src/scss/components/separador.scss
+++ b/src/scss/components/separador.scss
@@ -1,0 +1,47 @@
+.separador {
+  @include container-desktop;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2.4rem;
+  padding: 0 1.6rem;
+  margin: 3.2rem auto;
+  color: var(--space-blue);
+  background-color: var(--fondo-separador);
+
+  &__linea {
+    border-bottom: 0.1rem var(--pale-purple) solid;
+  }
+
+  &__titulo {
+    text-align: center;
+    margin: 0;
+    font-family: var(--font-playfair-display);
+    font-size: 2rem;
+    line-height: 3rem;
+    font-weight: 600;
+  }
+
+  &__descripcion {
+    text-align: center;
+    margin: 0 auto;
+    font-size: 1.6rem;
+    line-height: 2.4rem;
+    font-weight: 400;
+    width: 100%;
+    max-width: 87rem;
+  }
+}
+
+@include breakpoint('lg') {
+  .separador {
+    margin: 4rem auto;
+    padding: 0;
+
+    &__titulo {
+      font-size: 2.4rem;
+      line-height: 3.6rem;
+    }
+  }
+}

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -14,6 +14,7 @@
 @import './components/footer';
 @import './components/header';
 @import './components/hero';
+@import './components/separador';
 @import './components/beneficios';
 @import './components/tarjetaProducto';
 @import './components/personalizar';

--- a/templates/separador.hbs
+++ b/templates/separador.hbs
@@ -1,0 +1,18 @@
+<div class="separador"
+  {{#if colorDeFondo}}
+  style="--fondo-separador: var({{colorDeFondo}});"
+  {{/if}}
+  >
+  {{#if lineaSuperior}}
+  <span class="separador__linea"></span>
+  {{/if}}
+  {{#if titulo}}
+  <h1 class="separador__titulo">{{titulo}}</h1>
+  {{/if}}
+  {{#if descripcion}}
+  <p class="separador__descripcion">{{descripcion}}</p>
+  {{/if}}
+  {{#if lineaInferior}}
+  <span class="separador__linea"></span>
+  {{/if}}
+</div>


### PR DESCRIPTION
Agrega el componente separador con estilos y ajusta un espacio de márgenes del componente Entrada Blog para que quede como en los diseños.

- Este componente tiene líneas arriba y abajo, título, descripción y se puede modificar el color de fondo desde el CMS para que se ajuste a los diferentes componentes de Atalaya. 
- Todos los campos son opcionales, permitiendo configurar el separador a preferencia del editor: con o sin líneas, con una sola línea, con título y descripción, solo título, solo descripción, etc.

<img width="1789" alt="CMS" src="https://user-images.githubusercontent.com/28935600/207653807-7fa2386c-81c8-4c87-98e5-bc9a22f19ba3.png">

**Pasos para probar**
1. Clonar la rama separador-tibe
2. Correr el comando npm run dev
3. Ir a la página http://localhost:8080/blog.html
4. Usar las herramientas de desarrollador para ver los viewports mobile y desktop

**Mobile**
<img width="427" alt="Mobile" src="https://user-images.githubusercontent.com/28935600/207654014-f4d52ee9-ef43-49a3-847a-150c60da25f2.png">

**Desktop**
<img width="1789" alt="Desktop" src="https://user-images.githubusercontent.com/28935600/207654061-015416db-5fc9-4325-a058-94814fd9fcd9.png">
